### PR TITLE
Update img_to_vec.py

### DIFF
--- a/img2vec_pytorch/img_to_vec.py
+++ b/img2vec_pytorch/img_to_vec.py
@@ -30,7 +30,7 @@ class Img2Vec():
 
         self.model.eval()
 
-        self.scaler = transforms.Scale((224, 224))
+        self.scaler = transforms.Resize((224, 224))
         self.normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                               std=[0.229, 0.224, 0.225])
         self.to_tensor = transforms.ToTensor()


### PR DESCRIPTION
The use of the transforms.Scale transform is deprecated, please use transforms.Resize instead.