### PR TITLE
Add efficientnet models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,34 @@ Medium post on building the first version from scratch:  https://becominghuman.a
 
 ## Available models
  - Resnet-18 (CPU, GPU)
- 	- Returns vector length 512
+   - Returns vector length 512
  - Alexnet (CPU, GPU)
- 	- Returns vector length 4096
+   - Returns vector length 4096
  - Vgg-11 (CPU, GPU)
-	- Returns vector length 4096
+   - Returns vector length 4096
  - Densenet (CPU, GPU)
-	- Returns vector length 1024
+   - Returns vector length 1024
+ - EfficientNet (CPU, GPU)
+   - EfficientNet b0 ~b7
+ 
+|model|vector length|
+|----|----|
+|efficientnet_b0|1280|
+|efficientnet_b1|1280|
+|efficientnet_b2|1408|
+|efficientnet_b3|1536|
+|efficientnet_b4|1792|
+|efficientnet_b5|2048|
+|efficientnet_b6|2304|
+|efficientnet_b7|2560|
 
 ## Installation
 
-Tested on Python 3.6
+Tested on Python 3.6 and torchvision 0.11.0 (nightly, 2021-09-25) 
 
 Requires Pytorch: http://pytorch.org/
+
+```conda install -c pytorch-nightly torchvision```
 
 ```pip install img2vec_pytorch```
 
@@ -152,6 +167,9 @@ densenet.features = nn.Sequential(OrderedDict([
 	('pool0', nn.MaxPool2d(kernel_size=3, stride=2, padding=1)),
 ]))
 ```
+
+### [EfficientNet](https://arxiv.org/abs/1905.11946)
+Defaults: (layer = 1 from features, layer_output_size = 1280 for efficientnet_b0 model)<br>
 
 
 ## To-do

--- a/README.md
+++ b/README.md
@@ -9,19 +9,12 @@ Medium post on building the first version from scratch:  https://becominghuman.a
  - Image compression
 
 ## Available models
- - Resnet-18 (CPU, GPU)
-   - Returns vector length 512
- - Alexnet (CPU, GPU)
-   - Returns vector length 4096
- - Vgg-11 (CPU, GPU)
-   - Returns vector length 4096
- - Densenet (CPU, GPU)
-   - Returns vector length 1024
- - EfficientNet (CPU, GPU)
-   - EfficientNet b0 ~b7
- 
-|model|vector length|
+|Model name|Return vector length|
 |----|----|
+|Resnet-18|512|
+|Alexnet|4096|
+|Vgg-11|4096|
+|Densenet|1024|
 |efficientnet_b0|1280|
 |efficientnet_b1|1280|
 |efficientnet_b2|1408|

--- a/img2vec_pytorch/img_to_vec.py
+++ b/img2vec_pytorch/img_to_vec.py
@@ -10,7 +10,18 @@ class Img2Vec():
         'resnet34': 512,
         'resnet50': 2048,
         'resnet101': 2048,
-        'resnet152': 2048,
+        'resnet152': 2048
+    }
+
+    EFFICIENTNET_OUTPUT_SIZES = {
+        'efficientnet_b0': 1280,
+        'efficientnet_b1': 1280,
+        'efficientnet_b2': 1408,
+        'efficientnet_b3': 1536,
+        'efficientnet_b4': 1792,
+        'efficientnet_b5': 2048,
+        'efficientnet_b6': 2304,
+        'efficientnet_b7': 2560
     }
 
     def __init__(self, cuda=False, model='resnet-18', layer='default', layer_output_size=512):
@@ -46,7 +57,7 @@ class Img2Vec():
             images = torch.stack(a).to(self.device)
             if self.model_name in ['alexnet', 'vgg']:
                 my_embedding = torch.zeros(len(img), self.layer_output_size)
-            elif self.model_name == 'densenet':
+            elif self.model_name == 'densenet' or 'efficientnet' in self.model_name:
                 my_embedding = torch.zeros(len(img), self.layer_output_size, 7, 7)
             else:
                 my_embedding = torch.zeros(len(img), self.layer_output_size, 1, 1)
@@ -64,7 +75,7 @@ class Img2Vec():
             else:
                 if self.model_name in ['alexnet', 'vgg']:
                     return my_embedding.numpy()[:, :]
-                elif self.model_name == 'densenet':
+                elif self.model_name == 'densenet' or 'efficientnet' in self.model_name:
                     return torch.mean(my_embedding, (2, 3), True).numpy()[:, :, 0, 0]
                 else:
                     return my_embedding.numpy()[:, :, 0, 0]
@@ -73,7 +84,7 @@ class Img2Vec():
 
             if self.model_name in ['alexnet', 'vgg']:
                 my_embedding = torch.zeros(1, self.layer_output_size)
-            elif self.model_name == 'densenet':
+            elif self.model_name == 'densenet' or 'efficientnet' in self.model_name:
                 my_embedding = torch.zeros(1, self.layer_output_size, 7, 7)
             else:
                 my_embedding = torch.zeros(1, self.layer_output_size, 1, 1)
@@ -148,6 +159,35 @@ class Img2Vec():
             if layer == 'default':
                 layer = model.features[-1]
                 self.layer_output_size = model.classifier.in_features # should be 1024
+            else:
+                raise KeyError('Un support %s for layer parameters' % model_name)
+
+            return model, layer
+
+        elif "efficientnet" in model_name:
+            # efficientnet-b0 ~ efficientnet-b7
+            if model_name == "efficientnet_b0":
+                model = models.efficientnet_b0(pretrained=True)
+            elif model_name == "efficientnet_b1":
+                model = models.efficientnet_b1(pretrained=True)
+            elif model_name == "efficientnet_b2":
+                model = models.efficientnet_b2(pretrained=True)
+            elif model_name == "efficientnet_b3":
+                model = models.efficientnet_b3(pretrained=True)
+            elif model_name == "efficientnet_b4":
+                model = models.efficientnet_b4(pretrained=True)
+            elif model_name == "efficientnet_b5":
+                model = models.efficientnet_b5(pretrained=True)
+            elif model_name == "efficientnet_b6":
+                model = models.efficientnet_b6(pretrained=True)
+            elif model_name == "efficientnet_b7":
+                model = models.efficientnet_b7(pretrained=True)
+            else:
+                raise KeyError('Un support %s.' % model_name)
+
+            if layer == 'default':
+                layer = model.features
+                self.layer_output_size = self.EFFICIENTNET_OUTPUT_SIZES[model_name]
             else:
                 raise KeyError('Un support %s for layer parameters' % model_name)
 

--- a/img2vec_pytorch/test_img_to_vec.py
+++ b/img2vec_pytorch/test_img_to_vec.py
@@ -2,7 +2,6 @@ import unittest
 from PIL import Image
 import numpy
 
-
 from . import Img2Vec
 
 class TestImg2Vec(unittest.TestCase):
@@ -37,6 +36,70 @@ class TestImg2Vec(unittest.TestCase):
         self.assertEqual(True, isinstance(vec, numpy.ndarray))
         self.assertEqual(1, vec.ndim)
         self.assertEqual(1024, vec.size)
+
+    def test_efficientnet_b0(self):
+        img2vec = Img2Vec(model='efficientnet_b0')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(1280, vec.size)
+
+    def test_efficientnet_b1(self):
+        img2vec = Img2Vec(model='efficientnet_b1')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(1280, vec.size)
+
+    def test_efficientnet_b2(self):
+        img2vec = Img2Vec(model='efficientnet_b2')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(1408, vec.size)
+
+    def test_efficientnet_b3(self):
+        img2vec = Img2Vec(model='efficientnet_b3')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(1536, vec.size)
+
+    def test_efficientnet_b4(self):
+        img2vec = Img2Vec(model='efficientnet_b4')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(1792, vec.size)
+
+    def test_efficientnet_b5(self):
+        img2vec = Img2Vec(model='efficientnet_b5')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(2048, vec.size)
+
+    def test_efficientnet_b6(self):
+        img2vec = Img2Vec(model='efficientnet_b6')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(2304, vec.size)
+
+    def test_efficientnet_b7(self):
+        img2vec = Img2Vec(model='efficientnet_b7')
+        img = Image.open('./example/test_images/cat.jpg')
+        vec = img2vec.get_vec(img)
+        self.assertEqual(True, isinstance(vec, numpy.ndarray))
+        self.assertEqual(1, vec.ndim)
+        self.assertEqual(2560, vec.size)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Efficientnet (b0~b7) model were added for image feature generation.
- Please note that effivientnet models needs torchvision nightly (0.11.0).
- You can install it by `conda install -c pytorch-nightly torchvision`.